### PR TITLE
ci: change _book to _site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,51 +1,51 @@
 name: Build and Deploy
 on: [push, pull_request]
 permissions:
-    contents: write
+  contents: write
 jobs:
-    build-and-deploy:
-        concurrency: ci-${{ github.ref }}
-        runs-on: ubuntu-latest
-        permissions:
-            pull-requests: write
-            actions: write
-            contents: write
-        steps:
-            - name: Checkout 🛎️
-              uses: actions/checkout@v4
+  build-and-deploy:
+    concurrency: ci-${{ github.ref }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: write
+      contents: write
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
 
-            # python ----
-            - uses: actions/checkout@v2
-            - name: Install uv
-              uses: astral-sh/setup-uv@v5
-            - name: "Set up Python"
-              uses: actions/setup-python@v5
-              with:
-                python-version-file: ".python-version"
+      # python ----
+      - uses: actions/checkout@v2
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
 
-            - name: Install the project
-              run: uv sync --all-extras --dev
+      - name: Install the project
+        run: uv sync --all-extras --dev
 
-            # quarto docs build ----
-            - uses: quarto-dev/quarto-actions/setup@v2
-              with:
-                  tinytex: true
+      # quarto docs build ----
+      - uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          tinytex: true
 
-            - name: Build docs
-              run: |
-                  uv run quarto render
+      - name: Build docs
+        run: |
+          uv run quarto render
 
-            - name: Deploy
-              uses: JamesIves/github-pages-deploy-action@v4
-              if: ${{ github.ref == 'refs/heads/main' }}
-              with:
-                  force: false
-                  folder: _book
-                  clean-exclude: pr-preview
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          force: false
+          folder: _site
+          clean-exclude: pr-preview
 
-            - name: Deploy (preview)
-              uses: rossjrw/pr-preview-action@v1
-              # if in a PR
-              if: ${{ github.event_name == 'pull_request' }}
-              with:
-                  source-dir: _book
+      - name: Deploy (preview)
+        uses: rossjrw/pr-preview-action@v1
+        # if in a PR
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          source-dir: _site


### PR DESCRIPTION
This fixes the build. Since quarto now deploys to a `_site` folder, our github workflow needed to put to the new folder.

edit: shoot -- I think my autoformatter also changed all the indentation :/